### PR TITLE
* Update linter to work with Unreal Engine 5.2.

### DIFF
--- a/Linter.uplugin
+++ b/Linter.uplugin
@@ -10,7 +10,7 @@
 	"DocsURL": "http://discord.gamemak.in",
 	"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/ca0639af6339476da86fa3bcf15de8ec",
 	"SupportURL": "http://discord.gamemak.in",
-	"EngineVersion": "5.1.0",
+	"EngineVersion": "5.2.0",
 	"CanContainContent": true,
 	"Installed": true,
 	"Modules": [

--- a/Source/Linter/Private/BatchRenameTool/BatchRenameTool.cpp
+++ b/Source/Linter/Private/BatchRenameTool/BatchRenameTool.cpp
@@ -34,7 +34,7 @@ FDlgBatchRenameTool::FDlgBatchRenameTool(const TArray<FAssetData> Assets)
 
 		TSharedPtr<SBorder> DialogWrapper =
 			SNew(SBorder)
-			.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+			.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
 			.Padding(4.0f)
 			[
 				SAssignNew(DialogWidget, SDlgBatchRenameTool)
@@ -289,14 +289,14 @@ void SDlgBatchRenameTool::Construct(const FArguments& InArgs)
 		.Padding(8.0f, 4.0f, 8.0f, 4.0f)
 		[
 			SNew(SUniformGridPanel)
-			.SlotPadding(FEditorStyle::GetMargin("StandardDialog.SlotPadding"))
-			.MinDesiredSlotWidth(FEditorStyle::GetFloat("StandardDialog.MinDesiredSlotWidth"))
-			.MinDesiredSlotHeight(FEditorStyle::GetFloat("StandardDialog.MinDesiredSlotHeight"))
+			.SlotPadding(FAppStyle::GetMargin("StandardDialog.SlotPadding"))
+			.MinDesiredSlotWidth(FAppStyle::GetFloat("StandardDialog.MinDesiredSlotWidth"))
+			.MinDesiredSlotHeight(FAppStyle::GetFloat("StandardDialog.MinDesiredSlotHeight"))
 			+ SUniformGridPanel::Slot(0, 0)
 			[
 				SNew(SButton)
 				.HAlign(HAlign_Center)
-				.ContentPadding(FEditorStyle::GetMargin("StandardDialog.ContentPadding"))
+				.ContentPadding(FAppStyle::GetMargin("StandardDialog.ContentPadding"))
 				.OnClicked(this, &SDlgBatchRenameTool::OnButtonClick, FDlgBatchRenameTool::Confirm)
 				.Text(LOCTEXT("SkeletonMergeOk", "OK"))
 			]
@@ -304,7 +304,7 @@ void SDlgBatchRenameTool::Construct(const FArguments& InArgs)
 			[
 				SNew(SButton)
 				.HAlign(HAlign_Center)
-				.ContentPadding(FEditorStyle::GetMargin("StandardDialog.ContentPadding"))
+				.ContentPadding(FAppStyle::GetMargin("StandardDialog.ContentPadding"))
 				.OnClicked(this, &SDlgBatchRenameTool::OnButtonClick, FDlgBatchRenameTool::Cancel)
 				.Text(LOCTEXT("SkeletonMergeCancel", "Cancel"))
 			]

--- a/Source/Linter/Private/LintRule.cpp
+++ b/Source/Linter/Private/LintRule.cpp
@@ -10,6 +10,7 @@
 #include "IAssetRegistry.h"
 #include "IAssetTools.h"
 #include "AssetRegistryModule.h"
+#include "MaterialDomain.h"
 
 
 ULintRule::ULintRule(const FObjectInitializer& ObjectInitializer)

--- a/Source/Linter/Private/LintRules/LintRule_Blueprint_Vars_ConfigCategories.cpp
+++ b/Source/Linter/Private/LintRules/LintRule_Blueprint_Vars_ConfigCategories.cpp
@@ -2,6 +2,7 @@
 #include "LintRules/LintRule_Blueprint_Vars_ConfigCategories.h"
 #include "LintRuleSet.h"
 #include "Engine/Blueprint.h"
+#include "Kismet2/BlueprintEditorUtils.h"
 #include "EdGraphSchema_K2.h"
 
 ULintRule_Blueprint_Vars_ConfigCategories::ULintRule_Blueprint_Vars_ConfigCategories(const FObjectInitializer& ObjectInitializer)

--- a/Source/Linter/Private/LintRules/LintRule_Blueprint_Vars_RegEx.cpp
+++ b/Source/Linter/Private/LintRules/LintRule_Blueprint_Vars_RegEx.cpp
@@ -32,7 +32,7 @@ bool ULintRule_Blueprint_Vars_Regex::PassesRule_Internal_Implementation(UObject*
 		FText TypeName = UEdGraphSchema_K2::TypeToText(Desc.VarType);
 		bool bIsBool = Desc.VarType.PinCategory == UEdGraphSchema_K2::PC_Boolean;
 		
-		FRegexMatcher Matcher(bIsBool ? BoolTestRegexPattern : TestRegexPattern, PropName);
+		FRegexMatcher Matcher((bIsBool && bUseLowercaseBPrefixForBooleans) ? BoolTestRegexPattern : TestRegexPattern, PropName);
 		bool bFoundMatch = Matcher.FindNext();
 
 		if ((bFoundMatch && bMustNotContainRegexPattern) || (!bFoundMatch && !bMustNotContainRegexPattern))

--- a/Source/Linter/Private/LinterCommandlet.cpp
+++ b/Source/Linter/Private/LinterCommandlet.cpp
@@ -258,6 +258,10 @@ int32 ULinterCommandlet::Main(const FString& InParams)
 			}
 		}
 	}
+	if (Switches.Contains(TEXT("IgnoreErrors")))
+	{
+		return 0;
+	}
 
 	if (NumErrors > 0 || Switches.Contains(TEXT("TreatWarningsAsErrors")) && NumWarnings > 0)
 	{

--- a/Source/Linter/Private/LinterContentBrowserExtensions.cpp
+++ b/Source/Linter/Private/LinterContentBrowserExtensions.cpp
@@ -28,7 +28,7 @@ void FLinterContentBrowserExtensions::InstallHooks(FLinterModule* LinterModule, 
 		{
 			TSharedRef<FExtender> Extender = MakeShared<FExtender>();
 			Extender->AddMenuExtension(
-				"PathContextSourceControl",
+				"PathContextBulkOperations",
 				EExtensionHook::After,
 				TSharedPtr<FUICommandList>(),
 				FMenuExtensionDelegate::CreateStatic(&Local::ContentBrowserExtenderFunc, SelectedPaths)

--- a/Source/Linter/Private/LinterNamingConvention.cpp
+++ b/Source/Linter/Private/LinterNamingConvention.cpp
@@ -1,4 +1,6 @@
 #include "LinterNamingConvention.h"
+
+#include "AnyObject_LinterDummyClass.h"
 #include "DetailLayoutBuilder.h"
 #include "PropertyCustomizationHelpers.h"
 #include "Templates/SharedPointer.h"

--- a/Source/Linter/Private/LinterStyle.cpp
+++ b/Source/Linter/Private/LinterStyle.cpp
@@ -81,7 +81,7 @@ void FLinterStyle::Initialize()
 		StyleSet->Set("Linter.Padding",  2.0f);
 
 		// PaCK Fonts
-		const FTextBlockStyle NormalText = FEditorStyle::GetWidgetStyle<FTextBlockStyle>("NormalText");
+		const FTextBlockStyle NormalText = FAppStyle::GetWidgetStyle<FTextBlockStyle>("NormalText");
 
 		FTextBlockStyle NameText = FTextBlockStyle(NormalText)
 			.SetColorAndOpacity(FLinearColor(0.9f, 0.9f, 0.9f));

--- a/Source/Linter/Private/TooltipTool/TooltipTool.cpp
+++ b/Source/Linter/Private/TooltipTool/TooltipTool.cpp
@@ -47,7 +47,7 @@ FTooltipTool::FTooltipTool(const TArray<FAssetData> Assets)
 
 		TSharedPtr<SBorder> DialogWrapper =
 			SNew(SBorder)
-			.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+			.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
 			.Padding(4.0f)
 			[
 				SAssignNew(DialogWidget, STooltipTool)
@@ -215,7 +215,7 @@ void STooltipTool::Construct(const FArguments& InArgs)
 											.AutoWidth()
 											[
 												SNew(SImage)
-												.Image(FEditorStyle::GetBrush(TEXT("Icons.Error")))
+												.Image(FAppStyle::GetBrush(TEXT("Icons.Error")))
 												.Visibility_Lambda([Item] {return Item.IsValid() ? (Item->HasMetaData(FBlueprintMetadata::MD_Tooltip) && Item->GetMetaData(FBlueprintMetadata::MD_Tooltip).Len() > 0 ? EVisibility::Collapsed : EVisibility::HitTestInvisible) : EVisibility::Collapsed; })
 											]
 											+ SHorizontalBox::Slot()
@@ -339,7 +339,7 @@ void STooltipTool::Construct(const FArguments& InArgs)
 											.AutoWidth()
 											[
 												SNew(SImage)
-												.Image(FEditorStyle::GetBrush(TEXT("Icons.Error")))
+												.Image(FAppStyle::GetBrush(TEXT("Icons.Error")))
 												.Visibility_Lambda([Item] {return (Item.IsValid() && Item->FunctionEntryNode != nullptr&&  !Item->FunctionEntryNode->MetaData.ToolTip.IsEmptyOrWhitespace()) ? EVisibility::Collapsed : EVisibility::Visible; })
 											]
 											+ SHorizontalBox::Slot()
@@ -501,7 +501,7 @@ void STooltipTool::Construct(const FArguments& InArgs)
 													.AutoWidth()
 													[
 														SNew(SImage)
-														.Image(FEditorStyle::GetBrush(TEXT("Icons.Error")))
+														.Image(FAppStyle::GetBrush(TEXT("Icons.Error")))
 														.Visibility_Lambda([Item] {return (Item.IsValid() && !Item->Tooltip.IsEmptyOrWhitespace()) ? EVisibility::Collapsed : EVisibility::Visible; })
 													]
 													+ SHorizontalBox::Slot()
@@ -572,7 +572,7 @@ void STooltipTool::Construct(const FArguments& InArgs)
 													.AutoWidth()
 													[
 														SNew(SImage)
-														.Image(FEditorStyle::GetBrush(TEXT("Icons.Error")))
+														.Image(FAppStyle::GetBrush(TEXT("Icons.Error")))
 														.Visibility_Lambda([Item] {return (Item.IsValid() && !Item->Tooltip.IsEmptyOrWhitespace()) ? EVisibility::Collapsed : EVisibility::Visible; })
 													]
 													+ SHorizontalBox::Slot()

--- a/Source/Linter/Private/UI/LintReport.cpp
+++ b/Source/Linter/Private/UI/LintReport.cpp
@@ -21,6 +21,9 @@
 #include "Dom/JsonValue.h"
 #include "DesktopPlatformModule.h"
 #include "IDesktopPlatform.h"
+#include "Linter.h"
+#include "LinterStyle.h"
+#include "Interfaces/IPluginManager.h"
 #include "Misc/FileHelper.h"
 #include "Widgets/Input/SComboButton.h"
 #include "UI/LintReportRuleDetails.h"
@@ -176,12 +179,12 @@ void SLintReport::Construct(const FArguments& Args)
 		.VAlign(VAlign_Top)
 		[
 			SNew(SBorder)
-			.BorderImage(FEditorStyle::GetBrush("NoBorder"))
+			.BorderImage(FAppStyle::GetBrush("NoBorder"))
 			.Padding(FMargin(4.0f, 0.0f, 4.0f, 2.0f))
 			//.Visibility_Lambda([&]() { return AssetErrorLists.Num() > 0 ? EVisibility::SelfHitTestInvisible : EVisibility::Collapsed; })
 			[
 				SNew(SBorder)
-				.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+				.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
 				.Padding(FMargin(2.0f, 0.0f, 2.0f, 2.0f))
 				[
 
@@ -194,8 +197,8 @@ void SLintReport::Construct(const FArguments& Args)
 					[
 						SAssignNew( ViewOptionsComboButton, SComboButton )
 						.ContentPadding(0)
-						.ForegroundColor_Lambda([&]() { return ViewOptionsComboButton->IsHovered() ? FEditorStyle::GetSlateColor("InvertedForeground") : FEditorStyle::GetSlateColor("DefaultForeground"); })
-						.ButtonStyle( FEditorStyle::Get(), "ToggleButton" ) // Use the tool bar item style for this button
+						.ForegroundColor_Lambda([&]() { return ViewOptionsComboButton->IsHovered() ? FAppStyle::GetSlateColor("InvertedForeground") : FAppStyle::GetSlateColor("DefaultForeground"); })
+						.ButtonStyle( FAppStyle::Get(), "ToggleButton" ) // Use the tool bar item style for this button
 						.OnGetMenuContent( this, &SLintReport::GetViewButtonContent )
 						.ButtonContent()
 						[
@@ -204,7 +207,7 @@ void SLintReport::Construct(const FArguments& Args)
 							.AutoWidth()
 							.VAlign(VAlign_Center)
 							[
-								SNew(SImage).Image( FEditorStyle::GetBrush("GenericViewButton") )
+								SNew(SImage).Image( FAppStyle::GetBrush("GenericViewButton") )
 							]
  
 							+SHorizontalBox::Slot()

--- a/Source/Linter/Private/UI/LintReportAssetDetails.cpp
+++ b/Source/Linter/Private/UI/LintReportAssetDetails.cpp
@@ -61,11 +61,11 @@ void SLintReportAssetDetails::Construct(const FArguments& Args)
 	ChildSlot
 	[
 		SNew(SBorder)
-		.BorderImage(FEditorStyle::GetBrush("NoBorder"))
+		.BorderImage(FAppStyle::GetBrush("NoBorder"))
 		.Padding(PaddingAmount)
 		[
 			SNew(SBorder)
-			.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+			.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
 			.Padding(PaddingAmount)
 			[
 				SNew(SVerticalBox)

--- a/Source/Linter/Private/UI/LintReportAssetError.cpp
+++ b/Source/Linter/Private/UI/LintReportAssetError.cpp
@@ -1,5 +1,7 @@
 // Copyright 2019-2020 Gamemakin LLC. All Rights Reserved.
 #include "UI/LintReportAssetError.h"
+
+#include "LinterStyle.h"
 #include "Widgets/Layout/SBorder.h"
 #include "Widgets/SBoxPanel.h"
 #include "Widgets/Layout/SExpandableArea.h"

--- a/Source/Linter/Private/UI/LintReportRuleDetails.cpp
+++ b/Source/Linter/Private/UI/LintReportRuleDetails.cpp
@@ -72,11 +72,11 @@ void SLintReportRuleDetails::Construct(const FArguments& Args)
 	ChildSlot
 	[
 		SNew(SBorder)
-		.BorderImage(FEditorStyle::GetBrush("NoBorder"))
+		.BorderImage(FAppStyle::GetBrush("NoBorder"))
 		.Padding(PaddingAmount)
 		[
 			SNew(SBorder)
-			.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+			.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
 			.Padding(PaddingAmount)
 			[
 				SNew(SVerticalBox)

--- a/Source/Linter/Private/UI/LintWizard.cpp
+++ b/Source/Linter/Private/UI/LintWizard.cpp
@@ -76,7 +76,7 @@ void SLintWizard::Construct(const FArguments& InArgs)
 	[
 		SNew(SBorder)
 		.Padding(18)
-		.BorderImage(FEditorStyle::GetBrush("Docking.Tab.ContentAreaBrush"))
+		.BorderImage(FAppStyle::GetBrush("Docking.Tab.ContentAreaBrush"))
 		[
 			SNew(SVerticalBox)
 			+ SVerticalBox::Slot()
@@ -84,10 +84,10 @@ void SLintWizard::Construct(const FArguments& InArgs)
 				SAssignNew(MainWizard, SWizard)
 				.ShowPageList(false)
 				.ShowCancelButton(false)
-				.ButtonStyle(FEditorStyle::Get(), "FlatButton.Default")
-				.CancelButtonStyle(FEditorStyle::Get(), "FlatButton.Default")
-				.FinishButtonStyle(FEditorStyle::Get(), "FlatButton.Success")
-				.ButtonTextStyle(FEditorStyle::Get(), "LargeText")
+				.ButtonStyle(FAppStyle::Get(), "FlatButton.Default")
+				.CancelButtonStyle(FAppStyle::Get(), "FlatButton.Default")
+				.FinishButtonStyle(FAppStyle::Get(), "FlatButton.Success")
+				.ButtonTextStyle(FAppStyle::Get(), "LargeText")
 				.CanFinish(true)
 				.FinishButtonText(LOCTEXT("FinishButtonText", "Close"))
 				.OnFinished_Lambda([&]()
@@ -104,7 +104,7 @@ void SLintWizard::Construct(const FArguments& InArgs)
 					.Padding(0)
 					[
 						SNew(STextBlock)
-						.TextStyle( FEditorStyle::Get(), "NewClassDialog.PageTitle" )
+						.TextStyle( FAppStyle::Get(), "NewClassDialog.PageTitle" )
 						.Text(LOCTEXT("LinterSelectionTitle", "Linter Rule Set Selection"))
 					]
 					// Title spacer
@@ -151,7 +151,7 @@ void SLintWizard::Construct(const FArguments& InArgs)
 					.Padding(0)
 					[
 						SNew(STextBlock)
-						.TextStyle( FEditorStyle::Get(), "NewClassDialog.PageTitle" )
+						.TextStyle( FAppStyle::Get(), "NewClassDialog.PageTitle" )
 						.Text(LOCTEXT("LinterReportTitle", "Lint Report"))
 					]
 					// Marketplace No Errors Required Text
@@ -192,7 +192,7 @@ void SLintWizard::Construct(const FArguments& InArgs)
 					.Padding(0)
 					[
 						SNew(STextBlock)
-						.TextStyle( FEditorStyle::Get(), "NewClassDialog.PageTitle" )
+						.TextStyle( FAppStyle::Get(), "NewClassDialog.PageTitle" )
 						.Text(LOCTEXT("MarketplaceInfoTitle", "Marketplace Recommendations"))
 					]
 					// Title spacer
@@ -215,11 +215,11 @@ void SLintWizard::Construct(const FArguments& InArgs)
 							.AutoHeight()
 							[
 								SNew(SBorder)
-								.BorderImage(FEditorStyle::GetBrush("NoBorder"))
+								.BorderImage(FAppStyle::GetBrush("NoBorder"))
 								.Padding(PaddingAmount)
 								[
 									SNew(SBorder)
-									.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+									.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
 									.Padding(PaddingAmount)
 									[
 										SNew(SHorizontalBox)
@@ -322,12 +322,12 @@ void SLintWizard::Construct(const FArguments& InArgs)
 							.Padding(PaddingAmount)
 							[
 								SNew(SBorder)
-								.BorderImage(FEditorStyle::GetBrush("NoBorder"))
+								.BorderImage(FAppStyle::GetBrush("NoBorder"))
 								.Padding(PaddingAmount)
 								.Visibility_Lambda([&](){ return (MapAssetDataList.Num() > 0) ? EVisibility::SelfHitTestInvisible : EVisibility::Collapsed; })
 								[
 									SNew(SBorder)
-									.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+									.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
 									.Padding(PaddingAmount)
 									[
 										SNew(SVerticalBox)
@@ -429,11 +429,11 @@ void SLintWizard::Construct(const FArguments& InArgs)
 							[
 								SNew(SBorder)
 								.Visibility(EVisibility::Collapsed)
-								.BorderImage(FEditorStyle::GetBrush("NoBorder"))
+								.BorderImage(FAppStyle::GetBrush("NoBorder"))
 								.Padding(PaddingAmount)
 								[
 									SNew(SBorder)
-									.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+									.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
 									.Padding(PaddingAmount)
 									[
 										SNew(SVerticalBox)
@@ -522,7 +522,7 @@ void SLintWizard::Construct(const FArguments& InArgs)
 																	FString CommandLine = FString::Printf(TEXT("ZipProjectUp %s -project=\"%s\" -install=\"%s\""), UATFlags, *ProjectPath, *FinalFileName);
 
 																	IUATHelperModule::Get().CreateUatTask(CommandLine, PlatformName, LOCTEXT("ZipTaskName", "Zipping Up Project"),
-																		LOCTEXT("ZipTaskShortName", "Zip Project Task"), FEditorStyle::GetBrush(TEXT("MainFrame.CookContent")));
+																		LOCTEXT("ZipTaskShortName", "Zip Project Task"), FAppStyle::GetBrush(TEXT("MainFrame.CookContent")));
 																}
 
 																FGlobalTabmanager::Get()->FTabManager::TryInvokeTab(FName("LinterTab"))->RequestCloseTab();

--- a/Source/Linter/Private/UI/LintWizard.cpp
+++ b/Source/Linter/Private/UI/LintWizard.cpp
@@ -551,7 +551,7 @@ void SLintWizard::Construct(const FArguments& InArgs)
 	FContentBrowserModule& ContentBrowserModule = FModuleManager::Get().LoadModuleChecked<FContentBrowserModule>("ContentBrowser");
 	TArray<FAssetData> AssetDatas;
 	FARFilter Filter;
-	Filter.ClassNames.Add(UWorld::StaticClass()->GetFName());
+	Filter.ClassPaths.Add(UWorld::StaticClass()->GetClassPathName());
 	Filter.bRecursivePaths = true;
 	Filter.PackagePaths.Add(TEXT("/Game"));
 	AssetRegistryModule.Get().GetAssets(Filter, AssetDatas);

--- a/Source/Linter/Private/UI/SStepWidget.cpp
+++ b/Source/Linter/Private/UI/SStepWidget.cpp
@@ -56,11 +56,11 @@ void SStepWidget::Construct(const FArguments& Args)
 	ChildSlot
 	[
 		SNew(SBorder)
-		.BorderImage(FEditorStyle::GetBrush("NoBorder"))
+		.BorderImage(FAppStyle::GetBrush("NoBorder"))
 		.Padding(PaddingAmount)
 		[
 			SNew(SBorder)
-			.BorderImage(FEditorStyle::GetBrush("ToolPanel.GroupBorder"))
+			.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
 			.Padding(PaddingAmount)
 			[
 				SNew(SHorizontalBox)

--- a/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_ConfigCategories.h
+++ b/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_ConfigCategories.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "LintRule.h"
+#include "LintRule_Blueprint_Base.h"
 
 #include "LintRule_Blueprint_Vars_ConfigCategories.generated.h"
 

--- a/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_Regex.h
+++ b/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_Regex.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "LintRule.h"
+#include "LintRule_Blueprint_Base.h"
 
 #include "LintRule_Blueprint_Vars_Regex.generated.h"
 
@@ -15,7 +16,7 @@ public:
 	ULintRule_Blueprint_Vars_Regex(const FObjectInitializer& ObjectInitializer);
 
 	UPROPERTY(EditDefaultsOnly, Category = "Settings")
-	bool bUseLowercaseBPrefixForBooleans = true;
+	bool bUseLowercaseBPrefixForBooleans = false;
 
 	UPROPERTY(EditAnywhere, Category = "Settings")
 	FString RegexPatternString;

--- a/Source/Linter/Public/LinterNamingConvention.h
+++ b/Source/Linter/Public/LinterNamingConvention.h
@@ -3,6 +3,7 @@
 #pragma once
 #include "CoreMinimal.h"
 #include "UObject/Object.h"
+#include "Engine/DataAsset.h"
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
 #include "PropertyHandle.h"


### PR DESCRIPTION
Relevant changes:
FEditorStyle was deprecated, updated to FAppStyle

Added imports missing with IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_2;

**This one is non-obvious**
Updated Extender->AddMenuExtension from using PathContextSourceControl to PathContextBulkOperations. 5.2 changed the context menu to not include PathContextSourceControl, so the main linter option wasn't showing up in the context menu for 5.2, changing to PathContextBulkOperations fixes that.